### PR TITLE
Ignore tags generated by vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ html.vim
 ruby.vim
 sgml.vim
 xhtml.vim
+doc/tags


### PR DESCRIPTION
Added doc/tags to .gitignore because when managing vim plugins withgit
submodules the generated tags makes the repository "dirty".
