### PR TITLE
Mapping LocalLeader+. or > for different map

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -562,6 +562,9 @@ setlocal commentstring=<!--%s-->
 if !exists("g:xml_tag_completion_map")
     inoremap <buffer> <LocalLeader>. >
     inoremap <buffer> <LocalLeader>> >
+else
+    execute "inoremap <buffer> <LocalLeader>. " . g:xml_tag_completion_map
+    execute "inoremap <buffer> <LocalLeader>> " . g:xml_tag_completion_map
 endif
 
 " Jump between the beggining and end tags.


### PR DESCRIPTION
This allows you to change the `g:xml_tag_completion_map`
setting but still easily type the mapped character
using the `<LocalLeader>` syntax that types > when
there is no such map.
