### PR TITLE
Load xmledit plugin, even if $VIMRUNTIME/ftplugin/xml.vim or html.vim load first.

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -7,10 +7,10 @@
 " Original script can be seen in xml-plugin documentation.
 
 " Only do this when not done yet for this buffer
-if exists("b:did_ftplugin") || (!exists ("g:xmledit_enable_html")) || g:xmledit_enable_html != 1
+if exists("b:did_xmledit_ftplugin") || (!exists ("g:xmledit_enable_html")) || g:xmledit_enable_html != 1
     finish
 endif
-" Don't set 'b:did_ftplugin = 1' because that is xml.vim's responsability.
+" Don't set 'b:did_xmledit_ftplugin = 1' because that is xml.vim's responsability.
 
 let b:html_mode = 1
 

--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -32,9 +32,12 @@
 "==============================================================================
 
 " Only do this when not done yet for this buffer
-if exists("b:did_ftplugin") || exists("loaded_xmledit")
+if exists("b:did_xmledit_ftplugin") || exists("loaded_xmledit")
   finish
 endif
+
+let b:did_xmledit_ftplugin = 1
+
 " sboles, init these variables so vim doesn't complain on wrap cancel
 let b:last_wrap_tag_used = ""
 let b:last_wrap_atts_used = ""


### PR DESCRIPTION
Hi, 
Since I use neobundle to manage plugins, the load path of xmledit plugin should be after $VIMRUNTIME/ftplugin. I found that if xml.vim and html.vim located in $VIMRUNTIME/ftplugin is loaded, the xmledit plugin must not be loaed. It seems that xmledit use the same buffer variable -- 'b:did_ftplugin'  to avoid plugin loaded again. So I add the patch to load xmledit plugin, even if $VIMRUNTIME/ftplugin/xml.vim or html.vim load first.

Thanks & Best Regards,
Liang Feng
