### PR TITLE
Fix tag matching when maplocalleader was changed.

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -451,7 +451,7 @@ function s:DeleteTag( )
         return
     endif
     normal! mz
-    normal \5
+    call s:TagMatch1()
     normal! d%`zd%
 endfunction
 endif
@@ -467,7 +467,7 @@ function s:VisualTag( )
         return
     endif
     normal! mz
-    normal \5
+    call s:TagMatch1()
     normal! %
     exe "normal! " . visualmode()
     normal! `z


### PR DESCRIPTION
A few of the xmledit functions relied on a mapping done by this script.

I changed my 'maplocalleader' variable and since this mapping would no longer fire, selecting a matching tag failed. 

This fix just calls the necessary function directly.
