### PR TITLE
Remove asterisks emphasizing notes

### DIFF
--- a/doc/xml-plugin.txt
+++ b/doc/xml-plugin.txt
@@ -100,7 +100,7 @@ for details.
         your selection. If you are in visual line mode, the comment tags will
         be placed on a new line before and after the selection.
 
-        *Note:* This mapping might conflict with NERDCommenter or similar
+        Note: This mapping might conflict with NERDCommenter or similar
         plugins. This plugin will not override any existing mappings, but you
         might want to disable them if the plugin load order is special. See
         |xml-plugin-settings| for the 'xml_no_comment_map' setting and how to
@@ -151,7 +151,7 @@ for details.
         have selected text in visual mode before you can use this mapping. See
         |visual-mode| for details. Visual block mode isn't supported yet.
 
-        *Note:* This mapping might conflict with NERDCommenter or similar
+        Note: This mapping might conflict with NERDCommenter or similar
         plugins. This plugin will not override any existing mappings, but you
         might want to disable them if the plugin load order is special. See
         |xml-plugin-settings| for the 'xml_no_comment_map' setting and how to


### PR DESCRIPTION
Fixed bug causing:

> E154: Duplicate tag "Note:" in file ./xml-plugin.txt
> when building helptags
