### PR TITLE
Make tag autocompletion work if closing angular bracket is already inserted

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -557,12 +557,29 @@ if !exists("*s:InsertGt")
 function s:InsertGt( )
   let save_matchpairs = &matchpairs
   set matchpairs-=<:>
-  execute "normal! a>"
+  
+  " Check if a closing '>' already exists
+  " This is useful while using a plugin like delimitMate
+  " or a inoremap which autocompletes the closing >
+  " otherwise, an excess '>' is added
+  execute "normal! l" 
+  if (getline('.')[col('.') - 1 ] == '<')
+    " Nest the tags
+    execute "normal! i>"
+  elseif (getline('.')[col('.') - 1] == '>')
+    " closing > exists
+    execute "normal! a" 
+  else
+    " insert closing >
+    execute "normal! a>"
+  endif
+
   execute "set matchpairs=" . save_matchpairs
   " When the current char is text within a tag it will not proccess as a
   " syntax'ed element and return nothing below. Since the multi line wrap
   " feture relies on using the '>' char as text within a tag we must use the
   " char prior to establish if it is valid html/xml
+  "
   if (getline('.')[col('.') - 1] == '>')
     let char_syn=synIDattr(synID(line("."), col(".") - 1, 1), "name")
   endif


### PR DESCRIPTION
This makes it work with other plugins like delimitMate which automatically insert a '>' after the opening tag.

Fixes https://github.com/sukima/xmledit/issues/41
