### PR TITLE
Fixes regression bug in insertion of angle bracket

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -562,10 +562,10 @@ function s:InsertGt( )
   " This is useful while using a plugin like delimitMate
   " or a inoremap which autocompletes the closing >
   " otherwise, an excess '>' is added
-  if (getline('.')[col('.') - 1 ] == '<')
+  if (getline('.')[col('.')] == '<')
     " Nest the tags
     execute "normal! li>"
-  elseif (getline('.')[col('.') - 1] == '>')
+  elseif (getline('.')[col('.')] == '>')
     " closing > exists
     execute "normal! la"
   else


### PR DESCRIPTION
We need to update the index lookup for existing brackets after removing
that we always ran "normal! l" before everything.