### PR TITLE
Don't print an end-tag for <source>.

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -276,7 +276,7 @@ function s:ParseTag( )
         let index = index + 2
 
         " print out the end tag and place the cursor back were it left off
-        if html_mode && tag_name =~? '^\(img\|input\|param\|frame\|br\|hr\|meta\|link\|base\|area\)$'
+        if html_mode && tag_name =~? '^\(img\|input\|param\|frame\|br\|hr\|meta\|link\|base\|area\|source\)$'
             if has_attrib == 0
                 call <SID>Callback (tag_name, html_mode)
             endif


### PR DESCRIPTION
The HTML5 <source> tag, like <img>, has no end tag.

https://www.w3schools.com/tags/tag_source.asp