### PR TITLE
Added Project Description

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -17,6 +17,12 @@ and/or modify it under the terms of the GNU General Public
 License.  
 See <http://www.gnu.org/copyleft/gpl.txt>
 
+Description
+-----------
+This script provides some convenience when editing XML (and some SGML including HTML) formated documents. 
+It allows you to jump to the beginning or end of the tag block your cursor is in. `%` will jump between `<` and `>` within the tag your cursor is in. 
+When in insert mode and you finish a tag (pressing `>`) the tag will be completed. If you press `>` twice it will complete the tag and place the cursor in the middle of the tags on it's own line. 
+
 Install
 -------
 


### PR DESCRIPTION
A Project without a description doesn't make sense. The description is
already availabe at https://www.vim.org/scripts/script.php?script_id=301
though the git repo came first to me while searching.

The description is entirely copied/pasted from the vim.org page (with some minor modifications)